### PR TITLE
Update the README to use the correct chart repo

### DIFF
--- a/community-solid-server/README.md
+++ b/community-solid-server/README.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 ```bash
-helm repo add community-solid-server https://communitysolidserver.github.io/css-helm-chart/charts/
+helm repo add community-solid-server https://communitysolidserver.github.io/css-helm-chart/
 helm install my-css community-solid-server/community-solid-server
 ```
 
@@ -22,7 +22,7 @@ This chart bootstraps a [Community Solid Server](https://github.com/CommunitySol
 To install the chart with the release name my-css:
 
 ```bash
-helm repo add idlab-gent https://communitysolidserver.github.io/css-helm-chart/charts/
+helm repo add community-solid-server https://communitysolidserver.github.io/css-helm-chart/
 helm install my-css community-solid-server/community-solid-server
 ```
 


### PR DESCRIPTION
https://communitysolidserver.github.io/css-helm-chart/charts/ -> this repo leads to a (very) outdated helm repo, served from this folder: https://github.com/CommunitySolidServer/css-helm-chart/tree/gh-pages/charts/. The `index.yaml` file in that folder hasn't been updated for awhile.

https://communitysolidserver.github.io/css-helm-chart/ -> this repo uses the `index.yaml` in the root of https://github.com/CommunitySolidServer/css-helm-chart/tree/gh-pages/, which seems to get updated on a regular basis to point to the new github releases.