### PR TITLE
Revert to using https when generating a baseUrl

### DIFF
--- a/community-solid-server/templates/_helpers.tpl
+++ b/community-solid-server/templates/_helpers.tpl
@@ -68,8 +68,8 @@ Pass a correct baseUrl
 {{- if .Values.baseUrlOverride }}
 {{- .Values.baseUrlOverride }}
 {{- else if .Values.ingress.enabled }}
-{{- printf "http://%s%s" .Values.ingress.host .Values.ingress.path}}
+{{- printf "https://%s%s" .Values.ingress.host .Values.ingress.path}}
 {{- else }}
-{{- printf "http://%s.%s/" ( include "community-solid-server.fullname" . ) .Release.Namespace }}
+{{- printf "https://%s.%s/" ( include "community-solid-server.fullname" . ) .Release.Namespace }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`https` is a more secure default than `http`. Additionally, the previous helper file created `https` baseUrls, so upgrading to the new chart version will cause the base URL of the server to change if folks don't have `baseUrlOverride` set.